### PR TITLE
Attach the page console to Node's console

### DIFF
--- a/session.js
+++ b/session.js
@@ -98,6 +98,10 @@ expose(async (configFile, sessionId) => {
     await doStep();
   });
 
+  page.on('console', msg => {
+    log("console:" + msg.type(), sessionId, msg.text());
+  });
+
   log("session_start", sessionId, {
     entry,
     referer

--- a/session.js
+++ b/session.js
@@ -98,7 +98,7 @@ expose(async (configFile, sessionId) => {
     await doStep();
   });
 
-  page.on('console', msg => {
+  page.on("console", msg => {
     log("console:" + msg.type(), sessionId, msg.text());
   });
 


### PR DESCRIPTION
This allows catching errors loading the page. I think we might want to also attach to the error events, but I'll sort that later.