### PR TITLE
Catch loading errors

### DIFF
--- a/session.js
+++ b/session.js
@@ -98,6 +98,10 @@ expose(async (configFile, sessionId) => {
     await doStep();
   });
 
+  page.on('console', msg => {
+    log("console:" + msg.type(), sessionId, msg.text());
+  });
+
   log("session_start", sessionId, {
     entry,
     referer

--- a/session.js
+++ b/session.js
@@ -98,7 +98,7 @@ expose(async (configFile, sessionId) => {
     await doStep();
   });
 
-  page.on('console', msg => {
+  page.on("console", msg => {
     log("console:" + msg.type(), sessionId, msg.text());
   });
 


### PR DESCRIPTION
Builds off #2. Catches errors loading the page, and skips waiting around if there were errors.