### PR TITLE
Wait for completion

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,13 @@ if (!Array.isArray(config.funnels)) {
 // Quaid... start the reactor.
 (async () => {
   // Create worker pool.
-  const pool = Pool(() => spawn(new Worker("./session")), config.concurrency);
+  const pool = Pool(() => {
+    const worker = new Worker("./session");
+    worker.on('error', e => {
+      console.log(e);
+    });
+    return spawn( worker );
+  }, config.concurrency);
 
   // Queue sessions.
   for (i = 0; i < config.sessions; i++) {

--- a/session.js
+++ b/session.js
@@ -39,6 +39,10 @@ expose(async (configFile, sessionId) => {
   let currentStep = 0;
 
   // Handle session end.
+  let completer;
+  const completePromise = new Promise( ( resolve, reject ) => {
+    completer = { resolve, reject };
+  } );
   const done = async () => {
     log("session_end", sessionId);
     const timeOnPage = await resolve(funnel.timeOnPage || 2000, page);
@@ -47,6 +51,7 @@ expose(async (configFile, sessionId) => {
       runBeforeUnload: true
     });
     await browser.close();
+    completer.resolve();
     return;
   };
 
@@ -139,4 +144,5 @@ expose(async (configFile, sessionId) => {
     log("session_start_error", sessionId, error);
     await done();
   }
+  await completePromise;
 });

--- a/session.js
+++ b/session.js
@@ -43,7 +43,13 @@ expose(async (configFile, sessionId) => {
   const completePromise = new Promise( ( resolve, reject ) => {
     completer = { resolve, reject };
   } );
+  let didDone = false;
   const done = async () => {
+    if ( didDone ) {
+      return;
+    }
+    didDone = true;
+
     log("session_end", sessionId);
     const timeOnPage = await resolve(funnel.timeOnPage || 2000, page);
     await page.waitFor(timeOnPage);


### PR DESCRIPTION
Right now Trafficator will quit as soon as it can, which means it never sits around to wait for the funnel steps. When running concurrently, most of the workers will happen to wait around (because more events are getting queued, so the worker's getting reused and will naturally complete the stuff); however, the workers at the end of the lifecycle won't complete their tasks. You can see this trivially by setting concurrency and sessions to 1, and observing it never completes.

This uses a custom promise to wait on to block the main thread's exit until `done` is called. It does some naughty stuff by exposing resolve/reject outside of the promise constructor, but such is life.

Also adds some extra logging for errors inside workers.